### PR TITLE
Code optimization

### DIFF
--- a/sources/BrainMM.pas
+++ b/sources/BrainMM.pas
@@ -985,7 +985,7 @@ begin
       begin
         {$ifdef MSWINDOWS}
           //If we're (done) manipulating executable pages, make sure to Flush the cache so self-modifing code does not mess up.
-          if ((Rights and $4) > 0) then FlushInstructionCache(GetCurrentProcess, Pages, SIZE_K4 * Count);
+          if (marExecute in Rights) then FlushInstructionCache(GetCurrentProcess, Pages, SIZE_K4 * Count);
           if (not VirtualProtect(Pages, SIZE_K4 * Count, ACCESS_RIGHTS[Byte(Rights)], Protect)) then
             {$ifdef CONDITIONALEXPRESSIONS}System.Error(reInvalidPtr){$else}System.RunError(204){$endif};
         {$else .POSIX}


### PR DESCRIPTION
Hi Dmitry,  

I heard about your excellent work on Google+ Delphi.  
I'd like to suggest a couple of tweaks, see below.

I've only touched the x64 code, except where otherwise stated.  
- fixed jumps to naked `ret`: causes pipeline to be emptied on AMD wasting 25! cycles.
- Added `FlushInstructionCache` to secure self modifying code segments, see: http://stackoverflow.com/questions/7581321/how-to-make-fastcodepatch-work-in-delphi-xe2-win64-platform  
- Changed `bsf` to `rep bsf` (aka `TZCNT`) which is much faster on processors that support it and reverts to plain `bsf` on processors that don't.
- Added a faster version of `ZeroMem` than `STOSQ`. `STOSx` is rather slow except for very large fills.  
- Reordered some code to speed up on processors (ATOM) that do not support OoO execution.
- Complex `LEA` takes 2 cycles, replaced it with a single cycle `shl` where applicable.  
- replaced `NOP`'s with no-op prefixes where possible, this helps prediction accuracy on AMD because AMD stores instruction meta-data in the cache and if there are too many small instructions in a row meta-data drops out.  
- replaced a few repeated nops with multi-byte nops for the same reason.

Kindly let me know what you think.

Regards,

-- Johan Bontes
